### PR TITLE
stephen's h2 code

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,6 +12,10 @@ spring:
     password:
     platform: org.hibernate.dialect.H2Dialect
     initialization-mode: embedded
+  h2:
+    console:
+      enabled: true
+      path: /h2
 
 management:
   endpoint:


### PR DESCRIPTION
Stephen added in code that allows us to look at the H2 database info.

Now, while the server is running, you go in a browser to localhost:8080/h2.

To read the information, make sure the JDBC URL says:
jdbc:h2:mem:~/test

Then click Connect